### PR TITLE
大きい値のFFTを高速化

### DIFF
--- a/CompLib/Algorithm/FastFourierTransform.cs
+++ b/CompLib/Algorithm/FastFourierTransform.cs
@@ -1,24 +1,14 @@
 namespace CompLib.Algorithm
 {
+    using Mathematics;
     using System;
     using System.Numerics;
+
     public static class FastFourierTransform
     {
-        private const int E = 50;
-        private const long N = 1L << E;
-
-        // 1の原始N乗根
-        private const long O = 1521;
-        private const long InvO = 546857209190701451;
-
-        private const long Mod = 1012 * N + 1;
-
-        // private const int E = 27;
-        // private const long N = 1L << E;
-        // private const long O = 137;
-        // private const long InvO = 749463956;
-        // private const long Mod = 15 * N + 1;
-
+        private const int E = 26;
+        public static readonly ModInt O = new ModInt(18769, 136);
+        public static readonly ModInt InvO = new ModInt(137728885, 839354248);
 
         // Z[i] 1の原始2^i乗根
         public static readonly ModInt[] Z;
@@ -75,11 +65,11 @@ namespace CompLib.Algorithm
 
             ModInt[] nF = Transform(hatF, l, true);
 
-            ModInt invLen = ModInt.Pow(len, Mod - 2);
+            ModInt invLen = ModInt.Inverse(len);
             long[] f = new long[len];
             for (int i = 0; i < len; i++)
             {
-                f[i] = (nF[i] * invLen)._num;
+                f[i] = (nF[i] * invLen).Num;
             }
 
             return f;
@@ -227,11 +217,30 @@ namespace CompLib.Algorithm
 
         public struct ModInt
         {
-            public long _num { get; private set; }
+            private const long Mod1 = (1L << 27) * 15 + 1;
+            private const long Mod2 = (1L << 26) * 27 + 1;
+            public long Num1 { get; private set; }
+            public long Num2 { get; private set; }
+
+            public long Num
+            {
+                get
+                {
+                    long pq;
+                    return EMath.ChaineseRemainderTheorem(Num1, Mod1, Num2, Mod2, out pq);
+                }
+            }
 
             public ModInt(long n)
             {
-                _num = n % Mod;
+                Num1 = n % Mod1;
+                Num2 = n % Mod2;
+            }
+
+            public ModInt(long n, long m)
+            {
+                Num1 = n % Mod1;
+                Num2 = m % Mod2;
             }
 
             public static implicit operator ModInt(long n)
@@ -241,42 +250,12 @@ namespace CompLib.Algorithm
 
             public static ModInt operator *(ModInt a, ModInt b)
             {
-                if (Mod < int.MaxValue)
-                {
-                    return (a._num * b._num) % Mod;
-                }
-
-                long bb = b._num;
-                ModInt result = 0;
-                while (bb > 0)
-                {
-                    if (bb % 2 == 1)
-                    {
-                        result += a;
-                    }
-
-                    a += a;
-                    bb /= 2;
-                }
-
-                return result;
+                return new ModInt(a.Num1 * b.Num1, a.Num2 * b.Num2);
             }
 
             public static ModInt operator +(ModInt a, ModInt b)
             {
-                return (a._num + b._num) % Mod;
-            }
-
-            // a^(2^b)
-            public static ModInt Pow2(ModInt a, int b)
-            {
-                ModInt result = a;
-                for (int i = 0; i < b; i++)
-                {
-                    result *= result;
-                }
-
-                return result;
+                return new ModInt(a.Num1 + b.Num1, a.Num2 + b.Num2);
             }
 
             public static ModInt Pow(ModInt a, long b)
@@ -294,6 +273,43 @@ namespace CompLib.Algorithm
                 }
 
                 return result;
+            }
+
+            public static ModInt Inverse(int n)
+            {
+                long t1 = n;
+                long num1 = 1;
+                long b1 = Mod1 - 2;
+                while (b1 > 0)
+                {
+                    if (b1 % 2 == 1)
+                    {
+                        num1 *= t1;
+                        num1 %= Mod1;
+                    }
+
+                    t1 *= t1;
+                    t1 %= Mod1;
+                    b1 /= 2;
+                }
+
+                long t2 = n;
+                long num2 = 1;
+                long b2 = Mod2 - 2;
+                while (b2 > 0)
+                {
+                    if (b2 % 2 == 1)
+                    {
+                        num2 *= t2;
+                        num2 %= Mod2;
+                    }
+
+                    t2 *= t2;
+                    t2 %= Mod2;
+                    b2 /= 2;
+                }
+
+                return new ModInt(num1, num2);
             }
         }
     }

--- a/CompLib/Mathematics/ChaineseRemainderTheorem.cs
+++ b/CompLib/Mathematics/ChaineseRemainderTheorem.cs
@@ -1,0 +1,38 @@
+namespace CompLib.Mathematics
+{
+    public static partial class EMath
+    {
+        private static long Mod(long a, long m)
+        {
+            return (a % m + m) % m;
+        }
+
+        /// <summary>
+        /// n%p=a, n%q=b, n%lcm(p*q)を求める ただしa=b (mod gcd(p,q))
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="p"></param>
+        /// <param name="b"></param>
+        /// <param name="q"></param>
+        /// <returns></returns>
+        public static long ChaineseRemainderTheorem(long a, long p, long b, long q, out long pq)
+        {
+            long c, d;
+            long e = EMath.ExtGCD(p, q, out c, out d);
+            pq = p / e * q;
+            if (a % e != b % e)
+            {
+                return -1;
+            }
+
+            // pc + qd = e 
+
+            // n = a + p(b-a)c/e
+
+            // p(b-a)c/e (mod lcm(pq))
+
+            long tmp = (b - a) / e * c % (q / e);
+            return (a + Mod(p * tmp, pq)) % pq;
+        }
+    }
+}

--- a/CompLib/Mathematics/ExtGCD.cs
+++ b/CompLib/Mathematics/ExtGCD.cs
@@ -1,0 +1,27 @@
+namespace CompLib.Mathematics
+{
+    public partial class EMath
+    {
+        /// <summary>
+        /// ap+bq=gcd(a,b)を求め,gcd(a,b)を返す
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="p"></param>
+        /// <param name="q"></param>
+        /// <returns></returns>
+        public static long ExtGCD(long a, long b, out long p, out long q)
+        {
+            if (b == 0)
+            {
+                p = 1;
+                q = 0;
+                return a;
+            }
+
+            long d = ExtGCD(b, a % b, out q, out p);
+            q -= a / b * p;
+            return d;
+        }
+    }
+}

--- a/UnitTest/Algorithm/FastFourierTransformTest.cs
+++ b/UnitTest/Algorithm/FastFourierTransformTest.cs
@@ -120,7 +120,7 @@ namespace UnitTest.Algorithm
 
             for (int i = 0; i < n; i++)
             {
-                Assert.AreEqual(zetaNi[i]._num, zetaNi[i + n]._num);
+                Assert.AreEqual(zetaNi[i].Num, zetaNi[i + n].Num);
             }
 
             var invZetaN = FastFourierTransform.InvZ[4];
@@ -133,7 +133,7 @@ namespace UnitTest.Algorithm
 
             for (int i = 0; i < n; i++)
             {
-                Assert.AreEqual(invZetaNi[i]._num, invZetaNi[i + n]);
+                Assert.AreEqual(invZetaNi[i].Num, invZetaNi[i + n]);
             }
         }
 
@@ -174,7 +174,7 @@ namespace UnitTest.Algorithm
                         sum += zetaNji * barZetaNki;
                     }
 
-                    Assert.AreEqual(j == k ? n : 0, sum._num);
+                    Assert.AreEqual(j == k ? n : 0, sum.Num);
                 }
             }
 
@@ -198,7 +198,7 @@ namespace UnitTest.Algorithm
                         sum += invZetaNji * invBarZetaNki;
                     }
 
-                    Assert.AreEqual(j == k ? n : 0, sum._num);
+                    Assert.AreEqual(j == k ? n : 0, sum.Num);
                 }
             }
         }

--- a/UnitTest/Mathematics/ChaineseRemainderTheoremTest.cs
+++ b/UnitTest/Mathematics/ChaineseRemainderTheoremTest.cs
@@ -1,0 +1,55 @@
+using System;
+using CompLib.Mathematics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTest.Mathematics
+{
+    [TestClass]
+    public class ChaineseRemainderTheoremTest
+    {
+        [TestMethod]
+        public void RandomTest()
+        {
+            var rnd = new Random();
+            for (int i = 0; i < 100000; i++)
+            {
+                long n = rnd.Next();
+                long p = rnd.Next();
+                long q = rnd.Next();
+
+                long a = n % p;
+                long b = n % q;
+
+                long pq;
+                long ans = EMath.ChaineseRemainderTheorem(a, p, b, q, out pq);
+
+                Assert.IsTrue(pq % p == 0);
+                Assert.IsTrue(pq % q == 0);
+                Assert.AreEqual(ans % pq, n % pq);
+            }
+
+            for (int i = 0; i < 100000; i++)
+            {
+                long a = rnd.Next();
+                long b = rnd.Next();
+                long p = rnd.Next();
+                long q = rnd.Next();
+
+                long pq;
+                long ans = EMath.ChaineseRemainderTheorem(a, p, b, q, out pq);
+
+                long gcd = p * q / pq;
+
+                if (a % gcd == b % gcd)
+                {
+                    Assert.AreEqual(ans % p, a % p);
+                    Assert.AreEqual(ans % q, b % q);
+                }
+                else
+                {
+                    Assert.AreEqual(ans, -1);
+                }
+            }
+        }
+    }
+}

--- a/UnitTest/Mathematics/ExtGCDTest.cs
+++ b/UnitTest/Mathematics/ExtGCDTest.cs
@@ -1,0 +1,28 @@
+using System;
+using CompLib.Mathematics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTest.Mathematics
+{
+    [TestClass]
+    public class ExtGCDTest
+    {
+        [TestMethod]
+        public void RandomTest()
+        {
+            var rnd = new Random();
+            for (int i = 0; i < 100000; i++)
+            {
+                long a = rnd.Next();
+                long b = rnd.Next();
+
+                long p, q;
+                long gcd = EMath.ExtGCD(a, b, out p, out q);
+
+                Assert.IsTrue(a % gcd == 0);
+                Assert.IsTrue(b % gcd == 0);
+                Assert.AreEqual(a * p + b * q, gcd);
+            }
+        }
+    }
+}


### PR DESCRIPTION
前の実装だとMod > int.MaxValueならa * bがO(log b)で遅かったので
Modを2つ用意して中国剰余定理で値を復元するように
各演算がO(1), 復元がO(log Mod1)